### PR TITLE
Feature/lua updates

### DIFF
--- a/conf/before_components.mk
+++ b/conf/before_components.mk
@@ -14,7 +14,7 @@
 # ----------------------------------------------------------------------
 # Decide the conf and modulefile names.
 
-CHOSEN_MODULE=$(BUILD_TARGET)/wam-ipe
+CHOSEN_MODULE=$(BUILD_TARGET)/wam-ipe.lua
 
 CONFIGURE_NEMS_FILE=configure.wam-ipe.$(BUILD_TARGET)
 

--- a/modulefiles/wcoss2/wam-ipe.lua
+++ b/modulefiles/wcoss2/wam-ipe.lua
@@ -45,7 +45,7 @@ load(pathJoin("esmf", esmf_ver))
 
 -- comio load occurs out of $HOMEwfs/modulefiles and is implicitly specified
 -- by build.ver as the version of COMIO that is checked out comes from build.ver.
-prepend_path("MODULEPATH", "../../../modulefiles""
+prepend_path("MODULEPATH", "../../../modulefiles")
 comio_ver=os.getenv("comio_ver") or "0.0.10"
 load(pathJoin("comio", comio_ver))
 


### PR DESCRIPTION
Allows the build system to use modules.nems.lua instead of modules.nems -- other changes may still be necessary.